### PR TITLE
Liability email marketing consent

### DIFF
--- a/copy/event_applications/form_liability_agreement.html.erb
+++ b/copy/event_applications/form_liability_agreement.html.erb
@@ -1,9 +1,3 @@
-I agree to the terms of both the <a href="https://goo.gl/jMXKsO">
-MLH Contest Terms and Conditions </a> and the
-<a href="https://mlh.io/privacy"> MLH Privacy Policy </a>.
-Please note that you may receive pre and post-event
-informational e-mails and occasional messages about hackathons
-from MLH as per the MLH Privacy Policy. Also, by checking the box below
-you agree to UMass' <a href="http://hackumass.com/legal/HUMVPhotoRelease.pdf">
+By checking the box below you agree to UMass' <a href="http://hackumass.com/legal/HUMVPhotoRelease.pdf">
 Photo Release</a> requirement and <a href="http://hackumass.com/legal/HUMVLiabilityWaiver.pdf">
 Liability Waiver</a>.

--- a/event_application.yml
+++ b/event_application.yml
@@ -179,7 +179,3 @@ custom_fields:
   - name: song_recommendation
     label: "Any song recommendations for us to play at the event?"
     type: "textarea"
-  - name: consent_to_email
-    label: "Do you consent to receive emails from team@hackumass.com that contain information regarding this event? You will be able to opt-out at anytime through settings."
-    type: boolean
-    required: True


### PR DESCRIPTION
- Remove extra information about MLH from HUM's terms of services.
- Remove `consent_to_email` in **event_application.yml** since I moved it to registration form.